### PR TITLE
Implement BigNumberJSON.stringify

### DIFF
--- a/lib/json-bignum.js
+++ b/lib/json-bignum.js
@@ -360,3 +360,47 @@ BigNumberJSON.parse = (function () {
             : result;
     };
 }());
+
+BigNumberJSON.stringify = (function() {
+    "use strict";
+
+    var stringifyArray = function (arr) {
+        var buffer = '[';
+
+        for (var index=0; index<arr.length; index++) {
+            var item = arr[index];
+            if (index !== 0) {
+                buffer += ',';
+            }
+            buffer += stringify(item);
+        }
+
+        return buffer + ']';
+    };
+
+    var stringify = function(data) {
+        if (data instanceof BigNumber) {
+            return data.toString();
+        }
+
+        if (data instanceof Date || typeof data !== 'object') {
+            return JSON.stringify(data);
+        }
+
+        if (Array.isArray(data)) {
+            return stringifyArray(data);
+        }
+        var buffer = '{';
+
+        for (var k in data) {
+            if (buffer.length > 1) {
+                buffer += ',';
+            }
+            buffer += '"' + k + '":' + stringify(data[k]);
+        }
+
+        return buffer + '}';
+    };
+
+    return stringify;
+}());


### PR DESCRIPTION
This library does a fine job of parsing JSON, but for the purposes of sending BigNumber instances back to the server, it seems like a good idea to provide a BigNumberJSON.stringify() method.
